### PR TITLE
[fix] 상세페이지 시향 노트 리스트에서 더보기 이슈 수정

### DIFF
--- a/app/src/main/java/com/scentsnote/android/data/vo/response/ResponsePerfumeDetailWithReviews.kt
+++ b/app/src/main/java/com/scentsnote/android/data/vo/response/ResponsePerfumeDetailWithReviews.kt
@@ -1,5 +1,7 @@
 package com.scentsnote.android.data.vo.response
 
+import androidx.recyclerview.widget.DiffUtil
+
 data class ResponsePerfumeDetailWithReviews(
     val message: String,
     val data: List<PerfumeDetailWithReviews>
@@ -17,4 +19,20 @@ data class PerfumeDetailWithReviews(
     val nickname: String,
     val createTime: String,
     val isReported: Boolean
-)
+){
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<PerfumeDetailWithReviews>() {
+            override fun areItemsTheSame(
+                oldItem: PerfumeDetailWithReviews,
+                newItem: PerfumeDetailWithReviews
+            ): Boolean =
+                oldItem.reviewIdx == newItem.reviewIdx
+
+            override fun areContentsTheSame(
+                oldItem: PerfumeDetailWithReviews,
+                newItem: PerfumeDetailWithReviews
+            ): Boolean =
+                oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/com/scentsnote/android/data/vo/response/ResponsePerfumeDetailWithReviews.kt
+++ b/app/src/main/java/com/scentsnote/android/data/vo/response/ResponsePerfumeDetailWithReviews.kt
@@ -32,7 +32,7 @@ data class PerfumeDetailWithReviews(
                 oldItem: PerfumeDetailWithReviews,
                 newItem: PerfumeDetailWithReviews
             ): Boolean =
-                oldItem == newItem
+                oldItem.isLiked == newItem.isLiked
         }
     }
 }

--- a/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
@@ -17,6 +17,7 @@ import com.scentsnote.android.databinding.RvItemDetailNoteBinding
 import com.scentsnote.android.databinding.RvItemDetailNoteReportBinding
 import com.scentsnote.android.viewmodel.detail.PerfumeDetailViewModel
 import com.scentsnote.android.util.LayoutedTextView.OnLayoutListener
+import com.scentsnote.android.utils.extension.setOnSafeClickListener
 import com.scentsnote.android.utils.view.CommonDialog
 import com.scentsnote.android.utils.view.ReportDialog
 
@@ -43,21 +44,16 @@ class DetailNoteAdapter(
         when (viewType) {
             Default_TYPE -> {
                 val binding = RvItemDetailNoteBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false
+                    LayoutInflater.from(parent.context), parent, false
                 )
                 return DetailNoteViewHolder(
-                    parent.context,
-                    binding
+                    parent.context, binding
                 )
             }
 
             Report_TYPE -> {
                 val binding = RvItemDetailNoteReportBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false
+                    LayoutInflater.from(parent.context), parent, false
                 )
                 return DetailNoteReportViewHolder(
                     binding
@@ -93,7 +89,7 @@ class DetailNoteAdapter(
             binding.item = item
 
             /** 좋아요 버튼 */
-            binding.btnLike.setOnClickListener {
+            binding.btnLike.setOnSafeClickListener {
                 if (!ScentsNoteApplication.prefManager.haveToken()) createLoginDialog()
                 else {
                     clickBtnLike(item.reviewIdx)
@@ -101,7 +97,7 @@ class DetailNoteAdapter(
             }
 
             /** 신고 버튼 */
-            binding.txtRvDetailNoteReport.setOnClickListener {
+            binding.txtRvDetailNoteReport.setOnSafeClickListener {
                 if (!ScentsNoteApplication.prefManager.haveToken()) createLoginDialog()
                 else {
                     createReportDialog(item.reviewIdx)
@@ -118,7 +114,7 @@ class DetailNoteAdapter(
                 }
             })
 
-            binding.txtReviewMore.setOnClickListener {
+            binding.txtReviewMore.setOnSafeClickListener {
                 if (binding.txtDetailsReviewContent.maxLines > 3) {
                     isblurtype = true
                     binding.txtDetailsReviewContent.maxLines = 3
@@ -134,10 +130,7 @@ class DetailNoteAdapter(
                     binding.txtDetailsReviewContent.maxLines = Int.MAX_VALUE
                     binding.txtReviewMore.text = "접기"
                     binding.txtReviewMore.setCompoundDrawablesWithIntrinsicBounds(
-                        null,
-                        null,
-                        ContextCompat.getDrawable(context, R.drawable.icon_btn_up),
-                        null
+                        null, null, ContextCompat.getDrawable(context, R.drawable.icon_btn_up), null
                     )
                 }
             }
@@ -164,8 +157,7 @@ class DetailNoteAdapter(
 
                     override fun onNegativeClicked() {
                     }
-                })
-                .getInstance()
+                }).getInstance()
             dialog.arguments = bundle
             dialog.show(fragmentManager, dialog.tag)
         }
@@ -177,8 +169,7 @@ class DetailNoteAdapter(
                     txtReviewMore.visibility = View.VISIBLE
                     clReviewMore.background = if (isblurtype) {
                         ContextCompat.getDrawable(
-                            context,
-                            R.drawable.background_btn_details_more
+                            context, R.drawable.background_btn_details_more
                         )
                     } else {
                         ContextCompat.getDrawable(context, R.color.transparent)
@@ -195,6 +186,5 @@ class DetailNoteAdapter(
     }
 
     inner class DetailNoteReportViewHolder(val binding: RvItemDetailNoteReportBinding) :
-        RecyclerView.ViewHolder(binding.root) {
-    }
+        RecyclerView.ViewHolder(binding.root) {}
 }

--- a/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
@@ -27,7 +27,7 @@ class DetailNoteAdapter(
     val clickBtnLike: (Int) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     var data = mutableListOf<PerfumeDetailWithReviews>()
-    var firstType = true
+    var isblurtype = true
 
     /** 시향노트 표시 종류 : 2가지 */
     companion object {
@@ -128,13 +128,9 @@ class DetailNoteAdapter(
             })
 
             binding.txtReviewMore.setOnClickListener {
-                firstType = false
                 if (binding.txtDetailsReviewContent.maxLines > 3) {
+                    isblurtype = true
                     binding.txtDetailsReviewContent.maxLines = 3
-                    binding.clReviewMore.background = ContextCompat.getDrawable(
-                        context,
-                        R.drawable.background_btn_details_more
-                    )
                     binding.txtReviewMore.text = "더보기"
                     binding.txtReviewMore.setCompoundDrawablesWithIntrinsicBounds(
                         null,
@@ -143,9 +139,8 @@ class DetailNoteAdapter(
                         null
                     )
                 } else {
+                    isblurtype = false
                     binding.txtDetailsReviewContent.maxLines = Int.MAX_VALUE
-                    binding.clReviewMore.background =
-                        ContextCompat.getDrawable(context, R.color.transparent)
                     binding.txtReviewMore.text = "접기"
                     binding.txtReviewMore.setCompoundDrawablesWithIntrinsicBounds(
                         null,
@@ -188,11 +183,14 @@ class DetailNoteAdapter(
         fun setVisibilityMore(lineCount: Int, context: Context) {
             if (lineCount > 3) {
                 binding.txtReviewMore.visibility = View.VISIBLE
-                if (firstType) {
+                if (isblurtype) {
                     binding.clReviewMore.background = ContextCompat.getDrawable(
                         context,
                         R.drawable.background_btn_details_more
                     )
+                }else{
+                    binding.clReviewMore.background =
+                        ContextCompat.getDrawable(context, R.color.transparent)
                 }
             } else {
                 binding.txtReviewMore.visibility = View.GONE

--- a/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
@@ -28,12 +28,12 @@ class DetailNoteAdapter(
     private val clickBtnLike: (Int) -> Unit
 ) : ListAdapter<PerfumeDetailWithReviews, RecyclerView.ViewHolder>(PerfumeDetailWithReviews.diffUtil) {
 
-    private var isblurtype = true
+    private var isBlurType = true
 
     /** 시향노트 표시 종류 : 2가지 */
     companion object {
-        const val Default_TYPE = 0 // 일반 리뷰
-        const val Report_TYPE = 1 // 신고한 리뷰
+        const val DEFAULT_TYPE = 0 // 일반 리뷰
+        const val REPORT_TYPE = 1 // 신고한 리뷰
     }
 
     override fun getItemViewType(position: Int): Int {
@@ -42,7 +42,7 @@ class DetailNoteAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         when (viewType) {
-            Default_TYPE -> {
+            DEFAULT_TYPE -> {
                 val binding = RvItemDetailNoteBinding.inflate(
                     LayoutInflater.from(parent.context), parent, false
                 )
@@ -51,7 +51,7 @@ class DetailNoteAdapter(
                 )
             }
 
-            Report_TYPE -> {
+            REPORT_TYPE -> {
                 val binding = RvItemDetailNoteReportBinding.inflate(
                     LayoutInflater.from(parent.context), parent, false
                 )
@@ -68,14 +68,14 @@ class DetailNoteAdapter(
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (getItemViewType(position)) {
-            Default_TYPE -> {
+            DEFAULT_TYPE -> {
                 holder as DetailNoteViewHolder
                 currentList[position].let {
                     holder.bind(it)
                 }
             }
 
-            Report_TYPE -> {
+            REPORT_TYPE -> {
                 holder as DetailNoteReportViewHolder
             }
         }
@@ -116,7 +116,7 @@ class DetailNoteAdapter(
 
             binding.txtReviewMore.setOnSafeClickListener {
                 if (binding.txtDetailsReviewContent.maxLines > 3) {
-                    isblurtype = true
+                    isBlurType = true
                     binding.txtDetailsReviewContent.maxLines = 3
                     binding.txtReviewMore.text = "더보기"
                     binding.txtReviewMore.setCompoundDrawablesWithIntrinsicBounds(
@@ -126,7 +126,7 @@ class DetailNoteAdapter(
                         null
                     )
                 } else {
-                    isblurtype = false
+                    isBlurType = false
                     binding.txtDetailsReviewContent.maxLines = Int.MAX_VALUE
                     binding.txtReviewMore.text = "접기"
                     binding.txtReviewMore.setCompoundDrawablesWithIntrinsicBounds(
@@ -167,7 +167,7 @@ class DetailNoteAdapter(
             if (lineCount > 3) {
                 binding.run {
                     txtReviewMore.visibility = View.VISIBLE
-                    clReviewMore.background = if (isblurtype) {
+                    clReviewMore.background = if (isBlurType) {
                         ContextCompat.getDrawable(
                             context, R.drawable.background_btn_details_more
                         )

--- a/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.scentsnote.android.R
 import com.scentsnote.android.ScentsNoteApplication
@@ -23,11 +24,11 @@ import com.scentsnote.android.utils.view.ReportDialog
 class DetailNoteAdapter(
     private val vm: PerfumeDetailViewModel,
     private val fragmentManager: FragmentManager,
-    val perfumeIdx: Int,
-    val clickBtnLike: (Int) -> Unit
-) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    var data = mutableListOf<PerfumeDetailWithReviews>()
-    var isblurtype = true
+    private val perfumeIdx: Int,
+    private val clickBtnLike: (Int) -> Unit
+) : ListAdapter<PerfumeDetailWithReviews, RecyclerView.ViewHolder>(PerfumeDetailWithReviews.diffUtil) {
+
+    private var isblurtype = true
 
     /** 시향노트 표시 종류 : 2가지 */
     companion object {
@@ -35,21 +36,12 @@ class DetailNoteAdapter(
         const val Report_TYPE = 1 // 신고한 리뷰
     }
 
-    fun replaceAll(array: ArrayList<PerfumeDetailWithReviews>?) {
-        array?.let {
-            data.run {
-                clear()
-                addAll(it)
-            }
-        }
-    }
-
     override fun getItemViewType(position: Int): Int {
-        return if (data[position].isReported) 1 else 0
+        return if (currentList[position].isReported) 1 else 0
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return when (viewType) {
+        when (viewType) {
             Default_TYPE -> {
                 val binding = RvItemDetailNoteBinding.inflate(
                     LayoutInflater.from(parent.context),
@@ -83,7 +75,7 @@ class DetailNoteAdapter(
         when (getItemViewType(position)) {
             Default_TYPE -> {
                 holder as DetailNoteViewHolder
-                data[position].let {
+                currentList[position].let {
                     holder.bind(it)
                 }
             }
@@ -94,7 +86,7 @@ class DetailNoteAdapter(
         }
     }
 
-    override fun getItemCount(): Int = data.size
+    override fun getItemCount(): Int = currentList.size
 
     inner class DetailNoteViewHolder(val context: Context, val binding: RvItemDetailNoteBinding) :
         RecyclerView.ViewHolder(binding.root) {

--- a/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
@@ -180,7 +180,7 @@ class DetailNoteAdapter(
                         context,
                         R.drawable.background_btn_details_more
                     )
-                }else{
+                } else {
                     binding.clReviewMore.background =
                         ContextCompat.getDrawable(context, R.color.transparent)
                 }
@@ -192,6 +192,5 @@ class DetailNoteAdapter(
 
     inner class DetailNoteReportViewHolder(val binding: RvItemDetailNoteReportBinding) :
         RecyclerView.ViewHolder(binding.root) {
-
     }
 }

--- a/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteAdapter.kt
@@ -20,7 +20,6 @@ import com.scentsnote.android.util.LayoutedTextView.OnLayoutListener
 import com.scentsnote.android.utils.view.CommonDialog
 import com.scentsnote.android.utils.view.ReportDialog
 
-
 class DetailNoteAdapter(
     private val vm: PerfumeDetailViewModel,
     private val fragmentManager: FragmentManager,
@@ -174,18 +173,23 @@ class DetailNoteAdapter(
         /** 더보기 버튼 : 시향 노트 3줄 이상일 경우에는 더보기 버튼 표시 */
         fun setVisibilityMore(lineCount: Int, context: Context) {
             if (lineCount > 3) {
-                binding.txtReviewMore.visibility = View.VISIBLE
-                if (isblurtype) {
-                    binding.clReviewMore.background = ContextCompat.getDrawable(
-                        context,
-                        R.drawable.background_btn_details_more
-                    )
-                } else {
-                    binding.clReviewMore.background =
+                binding.run {
+                    txtReviewMore.visibility = View.VISIBLE
+                    clReviewMore.background = if (isblurtype) {
+                        ContextCompat.getDrawable(
+                            context,
+                            R.drawable.background_btn_details_more
+                        )
+                    } else {
                         ContextCompat.getDrawable(context, R.color.transparent)
+                    }
                 }
             } else {
-                binding.txtReviewMore.visibility = View.GONE
+                binding.run {
+                    txtReviewMore.visibility = View.GONE
+                    clReviewMore.background =
+                        ContextCompat.getDrawable(context, R.color.transparent)
+                }
             }
         }
     }

--- a/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteFragment.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Observer
 import com.scentsnote.android.R
 import com.scentsnote.android.databinding.FragmentDetailNoteBinding
 import com.scentsnote.android.viewmodel.detail.PerfumeDetailViewModel
@@ -24,9 +23,8 @@ class DetailNoteFragment(val perfumeIdx: Int) : Fragment() {
     private val viewModel: PerfumeDetailViewModel by activityViewModels()
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_detail_note, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
 
@@ -41,24 +39,35 @@ class DetailNoteFragment(val perfumeIdx: Int) : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
         viewModel.getPerfumeInfoWithReview(perfumeIdx)
-        viewModel.perfumeDetailWithReviewData.observe(viewLifecycleOwner){ reviews ->
+
+        viewModel.perfumeDetailWithReviewData.observe(viewLifecycleOwner) { reviews ->
             noteAdapter.submitList(reviews.map { it.copy() })
         }
 
-        viewModel.isValidNoteList.observe(requireActivity(), Observer {
-            if(it){
-                binding.rvDetailNote.visibility = View.VISIBLE
-                binding.txtDetailReviewList.visibility = View.GONE
-            }else{
-                binding.rvDetailNote.visibility = View.GONE
-                binding.txtDetailReviewList.visibility = View.VISIBLE
+        viewModel.isValidNoteList.observe(viewLifecycleOwner) {
+            if (it) {
+                binding.run {
+                    rvDetailNote.visibility = View.VISIBLE
+                    txtDetailReviewList.visibility = View.GONE
+                }
+            } else {
+                binding.run {
+                    rvDetailNote.visibility = View.GONE
+                    txtDetailReviewList.visibility = View.VISIBLE
+                }
             }
-        })
+        }
     }
 
-    private fun initNoteList(){
-        noteAdapter = DetailNoteAdapter(viewModel,parentFragmentManager,perfumeIdx){idx -> viewModel.postReviewLike(idx)}
-        binding.rvDetailNote.adapter = noteAdapter
+    private fun initNoteList() {
+        noteAdapter = DetailNoteAdapter(
+            viewModel, parentFragmentManager, perfumeIdx
+        ) { idx -> viewModel.postReviewLike(idx) }
+        binding.rvDetailNote.run {
+            adapter = noteAdapter
+            itemAnimator = null
+        }
     }
 }

--- a/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteFragment.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteFragment.kt
@@ -43,8 +43,7 @@ class DetailNoteFragment(val perfumeIdx: Int) : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         viewModel.getPerfumeInfoWithReview(perfumeIdx)
         viewModel.perfumeDetailWithReviewData.observe(requireActivity(), Observer {
-            noteAdapter.replaceAll(ArrayList(it))
-            noteAdapter.notifyDataSetChanged()
+            noteAdapter.submitList(ArrayList(it))
         })
 
         viewModel.isValidNoteList.observe(requireActivity(), Observer {
@@ -61,8 +60,5 @@ class DetailNoteFragment(val perfumeIdx: Int) : Fragment() {
     private fun initNoteList(){
         noteAdapter = DetailNoteAdapter(viewModel,parentFragmentManager,perfumeIdx){idx -> viewModel.postReviewLike(idx)}
         binding.rvDetailNote.adapter = noteAdapter
-
-        noteAdapter.notifyDataSetChanged()
-
     }
 }

--- a/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteFragment.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/detail/note/DetailNoteFragment.kt
@@ -42,9 +42,9 @@ class DetailNoteFragment(val perfumeIdx: Int) : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewModel.getPerfumeInfoWithReview(perfumeIdx)
-        viewModel.perfumeDetailWithReviewData.observe(requireActivity(), Observer {
-            noteAdapter.submitList(ArrayList(it))
-        })
+        viewModel.perfumeDetailWithReviewData.observe(viewLifecycleOwner){ reviews ->
+            noteAdapter.submitList(reviews.map { it.copy() })
+        }
 
         viewModel.isValidNoteList.observe(requireActivity(), Observer {
             if(it){

--- a/app/src/main/java/com/scentsnote/android/ui/filter/incense/IngredientFlexboxAdapter.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/filter/incense/IngredientFlexboxAdapter.kt
@@ -6,8 +6,8 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.scentsnote.android.data.vo.response.SeriesIngredient
 import com.scentsnote.android.databinding.RvItemSeriesIngredientFilterBinding
-import com.scentsnote.android.databinding.RvItemSeriesIngredientsFilterBinding
 import com.scentsnote.android.utils.extension.setOnSafeClickListener
 
 class IngredientFlexboxAdapter(
@@ -51,7 +51,7 @@ class IngredientFlexboxAdapter(
                 }
             }
 
-            binding.root.setOnSafeClickListener { it ->
+            binding.root.setOnSafeClickListener setOnClickListener@{ it ->
                 Log.d(TAG, "onClicked ingredientIdx: ${seriesIngredient.ingredientIdx}")
                 if (!seriesIngredient.clickable) {
                     Toast.makeText(

--- a/app/src/main/java/com/scentsnote/android/ui/search/DefaultPerfumeRecyclerViewAdapter.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/search/DefaultPerfumeRecyclerViewAdapter.kt
@@ -13,7 +13,7 @@ import com.scentsnote.android.data.vo.response.PerfumeInfo
 import com.scentsnote.android.databinding.RvItemDefaultPerfumeBinding
 import com.scentsnote.android.ui.detail.PerfumeDetailActivity
 import com.scentsnote.android.ui.detail.PerfumeDetailActivity.Companion.INTENT_EXTRA_PERFUME_IDX
-import com.scentsnote.android.util.createDialog
+import com.scentsnote.android.utils.createDialog
 import com.scentsnote.android.utils.extension.setOnSafeClickListener
 
 

--- a/app/src/main/java/com/scentsnote/android/utils/etc/NonNullMutableLiveData.kt
+++ b/app/src/main/java/com/scentsnote/android/utils/etc/NonNullMutableLiveData.kt
@@ -1,0 +1,12 @@
+package com.scentsnote.android.utils.etc
+
+import androidx.lifecycle.MutableLiveData
+
+class NonNullMutableLiveData<T : Any>(defaultValue: T) : MutableLiveData<T>() {
+
+    init {
+        value = defaultValue
+    }
+
+    override fun getValue()  = super.getValue()!!
+}

--- a/app/src/main/java/com/scentsnote/android/viewmodel/detail/PerfumeDetailViewModel.kt
+++ b/app/src/main/java/com/scentsnote/android/viewmodel/detail/PerfumeDetailViewModel.kt
@@ -19,7 +19,7 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 
-class PerfumeDetailViewModel: ViewModel() {
+class PerfumeDetailViewModel : ViewModel() {
     private val homeRepo = HomeRepository()
     private val detailRepo = PerfumeDetailRepository()
     private val compositeDisposable = CompositeDisposable()
@@ -27,37 +27,38 @@ class PerfumeDetailViewModel: ViewModel() {
     private val _perfumeDetailData: MutableLiveData<PerfumeDetail> = MutableLiveData()
     val perfumeDetailData: LiveData<PerfumeDetail> get() = _perfumeDetailData
 
-    private val _similarPerfumeList : MutableLiveData<MutableList<RecommendPerfumeItem>> = MutableLiveData()
-    val similarPerfumeList : LiveData<MutableList<RecommendPerfumeItem>>
+    private val _similarPerfumeList: MutableLiveData<MutableList<RecommendPerfumeItem>> =
+        MutableLiveData()
+    val similarPerfumeList: LiveData<MutableList<RecommendPerfumeItem>>
         get() = _similarPerfumeList
 
     // keyword 영역
     private val _isValidKeywordData = MutableLiveData<Boolean>(false)
-    val isValidKeywordData : LiveData<Boolean>
+    val isValidKeywordData: LiveData<Boolean>
         get() = _isValidKeywordData
 
     // note 영역
     private val _isValidNoteData = MutableLiveData<Boolean>(true)
-    val isValidNoteData : LiveData<Boolean>
+    val isValidNoteData: LiveData<Boolean>
         get() = _isValidNoteData
 
     private val _noteDataType = MutableLiveData<Boolean>(false)
-    val noteDataType : LiveData<Boolean>
+    val noteDataType: LiveData<Boolean>
         get() = _noteDataType
 
     // price 영역
     private val _isValidPriceData = MutableLiveData<Boolean>(false)
-    val isValidPriceData : LiveData<Boolean>
+    val isValidPriceData: LiveData<Boolean>
         get() = _isValidPriceData
 
     // season 영역
     private val _isValidSeasonChart = MutableLiveData<Boolean>(true)
-    val isValidSeasonChart : LiveData<Boolean>
+    val isValidSeasonChart: LiveData<Boolean>
         get() = _isValidSeasonChart
 
     // gender 영역
     private val _isValidGenderChart = MutableLiveData<Boolean>(true)
-    val isValidGenderChart : LiveData<Boolean>
+    val isValidGenderChart: LiveData<Boolean>
         get() = _isValidGenderChart
 
     /**
@@ -75,9 +76,9 @@ class PerfumeDetailViewModel: ViewModel() {
 
                     setDataVisibility(it.data)
 
-                    Log.d("getPerfumeInfo", it.toString())
+                    Log.d(TAG, "getPerfumeInfo: $it")
                 }) {
-                    Log.d("getPerfumeInfo error", it.toString())
+                    Log.d(TAG, "getPerfumeInfo error: $it")
 //                    Toast.makeText(context, "서버 점검 중입니다.", Toast.LENGTH_SHORT).show()
                 })
     }
@@ -87,18 +88,21 @@ class PerfumeDetailViewModel: ViewModel() {
      *
      * @param data 향수 상세 정보
      */
-    private fun setDataVisibility(data: PerfumeDetail){
+    private fun setDataVisibility(data: PerfumeDetail) {
         _isValidKeywordData.value = data.Keywords.isNotEmpty()
 
         _isValidPriceData.value = data.volumeAndPrice.isNotEmpty()
 
         _noteDataType.value = data.noteType == 1
 
-        if(data.noteType == 0 && data.ingredients.top.isEmpty() && data.ingredients.middle.isEmpty() && data.ingredients.base.isEmpty()) _isValidNoteData.value = false
+        if (data.noteType == 0 && data.ingredients.top.isEmpty() && data.ingredients.middle.isEmpty() && data.ingredients.base.isEmpty()) _isValidNoteData.value =
+            false
 
-        if(data.seasonal.spring == 0 && data.seasonal.summer == 0 && data.seasonal.fall == 0 && data.seasonal.winter == 0) _isValidSeasonChart.value = false
+        if (data.seasonal.spring == 0 && data.seasonal.summer == 0 && data.seasonal.fall == 0 && data.seasonal.winter == 0) _isValidSeasonChart.value =
+            false
 
-        if(data.gender.female == 0 && data.gender.neutral == 0 && data.gender.male == 0) _isValidGenderChart.value = false
+        if (data.gender.female == 0 && data.gender.neutral == 0 && data.gender.male == 0) _isValidGenderChart.value =
+            false
     }
 
     /**
@@ -107,13 +111,13 @@ class PerfumeDetailViewModel: ViewModel() {
      * @param perfumeIdx 조회 요청 향수의 idx
      */
     @SuppressLint("LongLogTag")
-    fun getSimilarPerfumeList(perfumeIdx: Int){
+    fun getSimilarPerfumeList(perfumeIdx: Int) {
         viewModelScope.launch {
-            try{
+            try {
                 _similarPerfumeList.value = detailRepo.getSimilarPerfumeList(perfumeIdx)
-                Log.d("getSimilarPerfumeList", _similarPerfumeList.value.toString())
-            }catch (e : HttpException){
-                Log.d("getSimilarPerfumeList error", _similarPerfumeList.value.toString())
+                Log.d(TAG, "getSimilarPerfumeList: ${_similarPerfumeList.value}")
+            } catch (e: HttpException) {
+                Log.d(TAG, "getSimilarPerfumeList error: ${_similarPerfumeList.value}")
             }
         }
     }
@@ -130,20 +134,26 @@ class PerfumeDetailViewModel: ViewModel() {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    clickHeartPerfumeList(_similarPerfumeList, perfumeIdx,it.data)
+                    clickHeartPerfumeList(_similarPerfumeList, perfumeIdx, it.data)
+                    Log.d(TAG, "postSimilarPerfumeLike: $it")
                 }) {
-                    Log.d("postSimilarPerfumeLike error", it.toString())
+                    Log.d(TAG, "postSimilarPerfumeLike error: $it")
 //                    Toast.makeText(context, "서버 점검 중입니다.", Toast.LENGTH_SHORT).show()
                 })
     }
 
-    private fun clickHeartPerfumeList(perfumeList: MutableLiveData<MutableList<RecommendPerfumeItem>>, perfumeIdx: Int, isSelected:Boolean){
+    private fun clickHeartPerfumeList(
+        perfumeList: MutableLiveData<MutableList<RecommendPerfumeItem>>,
+        perfumeIdx: Int,
+        isSelected: Boolean
+    ) {
         val tempList = perfumeList.value
-        tempList?.forEach { if(it.perfumeIdx==perfumeIdx) it.isLiked= isSelected}
-        perfumeList.value=tempList
+        tempList?.forEach { if (it.perfumeIdx == perfumeIdx) it.isLiked = isSelected }
+        perfumeList.value = tempList
     }
 
-    private val _perfumeDetailWithReviewData: MutableLiveData<List<PerfumeDetailWithReviews>> = MutableLiveData()
+    private val _perfumeDetailWithReviewData: MutableLiveData<List<PerfumeDetailWithReviews>> =
+        MutableLiveData()
     val perfumeDetailWithReviewData: LiveData<List<PerfumeDetailWithReviews>> get() = _perfumeDetailWithReviewData
 
     private val _isValidNoteList = MutableLiveData<Boolean>(false)
@@ -157,7 +167,10 @@ class PerfumeDetailViewModel: ViewModel() {
     @SuppressLint("LongLogTag")
     fun getPerfumeInfoWithReview(perfumeIdx: Int) {
         compositeDisposable.add(
-            detailRepo.getPerfumeDetailWithReviews(ScentsNoteApplication.prefManager.accessToken, perfumeIdx)
+            detailRepo.getPerfumeDetailWithReviews(
+                ScentsNoteApplication.prefManager.accessToken,
+                perfumeIdx
+            )
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
@@ -165,10 +178,10 @@ class PerfumeDetailViewModel: ViewModel() {
 
                     _isValidNoteList.value = it.data.isNotEmpty()
 
-                    Log.d("DETAILDATAWithReviews", it.toString())
+                    Log.d(TAG, "getPerfumeInfoWithReview: $it")
                 }) {
                     _isValidNoteList.postValue(false)
-                    Log.d("DETAILDATAWithReviews error", it.toString())
+                    Log.d(TAG, "getPerfumeInfoWithReview error: $it")
 //                    Toast.makeText(context, "서버 점검 중입니다.", Toast.LENGTH_SHORT).show()
                 })
     }
@@ -187,10 +200,10 @@ class PerfumeDetailViewModel: ViewModel() {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    Log.d("postPerfumeLike", it.toString())
-                    _perfumeLike.postValue(it.data)
+                    Log.d(TAG, "postPerfumeLike: $it")
+                    _perfumeLike.postValue(it.data!!)
                 }) {
-                    Log.d("postPerfumeLike error", it.toString())
+                    Log.d(TAG, "postPerfumeLike error: $it")
 //                    Toast.makeText(context, "서버 점검 중입니다.", Toast.LENGTH_SHORT).show()
                 })
     }
@@ -202,45 +215,46 @@ class PerfumeDetailViewModel: ViewModel() {
      *
      * @param reviewIdx 좋아요 누른 시향 노트의 idx
      */
-    fun postReviewLike(reviewIdx: Int){
+    fun postReviewLike(reviewIdx: Int) {
         viewModelScope.launch {
-            try{
-                detailRepo.postReviewLike(ScentsNoteApplication.prefManager.accessToken, reviewIdx).let{
-                    _reviewLike.postValue(it)
-                    clickHeartNoteList(reviewIdx, it)
-                    Log.d("시향 노트 좋아요 상태 : ", it.toString())
-                }
-            }catch (e : HttpException){
-                when(e.response()?.code()){
+            try {
+                detailRepo.postReviewLike(ScentsNoteApplication.prefManager.accessToken, reviewIdx)
+                    .let {
+                        _reviewLike.postValue(it)
+                        clickHeartNoteList(reviewIdx, it)
+                        Log.d(TAG, "postReviewLike: $it")
+                    }
+            } catch (e: HttpException) {
+                when (e.response()?.code()) {
                     401 -> { // 인증되지 않은 사용자
-                        Log.d("시향 노트 좋아요 실패 : ", e.message())
+                        Log.d(TAG, "postReviewLike Fail : $e")
                     }
                     403 -> { // 잘못된 접근
-                        Log.d("시향 노트 좋아요 실패 : ", e.message())
+                        Log.d(TAG, "postReviewLike Fail : $e")
                     }
                 }
             }
         }
     }
 
-    private fun clickHeartNoteList(reviewIdx: Int, isSelected:Boolean){
+    private fun clickHeartNoteList(reviewIdx: Int, isSelected: Boolean) {
         val tempList = _perfumeDetailWithReviewData.value
         tempList?.forEach {
-            if(it.reviewIdx==reviewIdx) {
-                it.isLiked= isSelected
-                if(it.isLiked){
+            if (it.reviewIdx == reviewIdx) {
+                it.isLiked = isSelected
+                if (it.isLiked) {
                     it.likeCount += 1
-                }else{
+                } else {
                     it.likeCount -= 1
                 }
             }
         }
-        _perfumeDetailWithReviewData.value=tempList
+        _perfumeDetailWithReviewData.value = tempList!!
     }
 
     private var reportTxt = MutableLiveData("")
 
-    fun setReportTxt(txt:String){
+    fun setReportTxt(txt: String) {
         reportTxt.value = txt
     }
 
@@ -252,17 +266,25 @@ class PerfumeDetailViewModel: ViewModel() {
      *
      * @param reviewIdx 신고 누른 시향 노트의 idx
      */
-    fun reportReview(reviewIdx: Int){
+    fun reportReview(reviewIdx: Int) {
         viewModelScope.launch {
-            try{
-                detailRepo.reportReview(ScentsNoteApplication.prefManager.accessToken, reviewIdx, RequestReportReview(reportTxt.value!!) ).let {
+            try {
+                detailRepo.reportReview(
+                    ScentsNoteApplication.prefManager.accessToken,
+                    reviewIdx,
+                    RequestReportReview(reportTxt.value!!)
+                ).let {
                     _isValidReport.postValue(true)
-                    Log.d("시향 노트 신고 성공",it)
+                    Log.d(TAG, "reportReview : $it")
                 }
-            }catch (e : HttpException){
+            } catch (e: HttpException) {
                 _isValidReport.postValue(false)
-                Log.d("시향 노트 신고 실패 : ", e.message())
+                Log.d(TAG, "reportReview Fail : $e")
             }
         }
+    }
+
+    companion object {
+        const val TAG = "PerfumeDetailViewModel"
     }
 }


### PR DESCRIPTION
### 설명
상세페이지 시향노트 리스트에서 내용이 3줄 이상인 시향노트 처리(더보기/접기 버튼 및 블러 효과)와 관련하여 버그 발생.
3줄 미만인 시향노트 중 블러 처리 되는 경우가 있음

### 원인
아래와 같이 배경 처리가 두 곳에서 이뤄지고 있어 발생한 이슈. onLayouted에서만 처리되도록 수정.
- onLayouted : 최초 그려질 당시 처리
- ClickListener : 버튼 클릭 후 처리

### 이슈
https://github.com/Scents-Note/A.fume.Android/issues/263