### PR TITLE
[bug] Clear selected filter on back pressed in search result page

### DIFF
--- a/app/src/main/java/com/scentsnote/android/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/scentsnote/android/ui/search/SearchFragment.kt
@@ -165,6 +165,9 @@ class SearchFragment : Fragment() {
 
     private fun clearFilterList() {
         viewModel.filter.value = SendFilter(null, null)
+        filterSeriesViewModel.clearSelectedList()
+        filterBrandViewModel.clearSelectedList()
+        filterKeywordViewModel.clearSelectedList()
     }
 
     private fun openSelectFilters() {


### PR DESCRIPTION
검색결과 페이지에서 뒤로가기 누르고 필터 다시 열면 이전에 선택한 필터가 선택되어 있는 버그 수정